### PR TITLE
Add spherical vector average coverage

### DIFF
--- a/src/NetFabric.Numerics.UnitTests/Spherical/AverageTests.cs
+++ b/src/NetFabric.Numerics.UnitTests/Spherical/AverageTests.cs
@@ -1,0 +1,89 @@
+namespace NetFabric.Numerics.Spherical.UnitTests;
+
+public class AverageTests
+{
+    public static TheoryData<Vector<Degrees, double>[], Vector<Degrees, double>?> AverageData
+        => new()
+        {
+            {
+                Array.Empty<Vector<Degrees, double>>(),
+                null
+            },
+            {
+                new[] { new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight) },
+                new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight)
+            },
+            {
+                new[]
+                {
+                    new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Right),
+                    new Vector<Degrees, double>(11.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Right),
+                },
+                new Vector<Degrees, double>(6.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Right)
+            },
+            {
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value,
+                        new Angle<Degrees, double>(value + 1),
+                        new Angle<Degrees, double>(value + 2)))
+                    .ToArray(),
+                new Vector<Degrees, double>(48.0, new Angle<Degrees, double>(49.0), new Angle<Degrees, double>(50.0))
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(AverageData))]
+    public void Average_For_Enumerable_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double>? expected)
+    {
+        // arrange
+        var enumerable = new ReadOnlyCollection<Vector<Degrees, double>>(source);
+
+        // act
+        var result = enumerable.Average();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(AverageData))]
+    public void Average_For_Array_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double>? expected)
+    {
+        // arrange
+
+        // act
+        var result = source.Average();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(AverageData))]
+    public void Average_For_Span_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double>? expected)
+    {
+        // arrange
+        var span = source.AsSpan();
+
+        // act
+        var result = span.Average();
+
+        // assert
+        result.Should().Be(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(AverageData))]
+    public void Average_For_ReadOnlySpan_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double>? expected)
+    {
+        // arrange
+        ReadOnlySpan<Vector<Degrees, double>> readOnlySpan = source;
+
+        // act
+        var result = readOnlySpan.Average();
+
+        // assert
+        result.Should().Be(expected);
+    }
+}

--- a/src/NetFabric.Numerics.UnitTests/Spherical/SpanSubtractMultiplyDivideTests.cs
+++ b/src/NetFabric.Numerics.UnitTests/Spherical/SpanSubtractMultiplyDivideTests.cs
@@ -1,0 +1,286 @@
+namespace NetFabric.Numerics.Spherical.UnitTests;
+
+public class SpanVectorSubtractMultiplyDivideTests
+{
+    public static TheoryData<Vector<Degrees, double>[], Vector<Degrees, double>, Vector<Degrees, double>[]> SubtractValueData
+        => new()
+        {
+            {
+                Array.Empty<Vector<Degrees, double>>(),
+                new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight),
+                Array.Empty<Vector<Degrees, double>>()
+            },
+            {
+                new[] { new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right) },
+                new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Straight),
+                new[] { new Vector<Degrees, double>(-2.0, new Angle<Degrees, double>(-90.0), new Angle<Degrees, double>(-90.0)) }
+            },
+            {
+                new[]
+                {
+                    new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right),
+                    new Vector<Degrees, double>(11.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Straight),
+                },
+                new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right),
+                new[]
+                {
+                    new Vector<Degrees, double>(-2.0, Angle<Degrees, double>.Zero, Angle<Degrees, double>.Zero),
+                    new Vector<Degrees, double>(8.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right),
+                }
+            },
+            {
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value,
+                        new Angle<Degrees, double>(value + 1),
+                        new Angle<Degrees, double>(value + 2)))
+                    .ToArray(),
+                new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight),
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value - 3,
+                        new Angle<Degrees, double>(value - 89),
+                        new Angle<Degrees, double>(value - 178)))
+                    .ToArray()
+            },
+        };
+
+    public static TheoryData<Vector<Degrees, double>[], Vector<Degrees, double>, Vector<Degrees, double>[]> MultiplyValueData
+        => new()
+        {
+            {
+                Array.Empty<Vector<Degrees, double>>(),
+                new Vector<Degrees, double>(3.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                Array.Empty<Vector<Degrees, double>>()
+            },
+            {
+                new[] { new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight) },
+                new Vector<Degrees, double>(3.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                new[] { new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Straight, new Angle<Degrees, double>(720.0)) }
+            },
+            {
+                new[]
+                {
+                    new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight),
+                    new Vector<Degrees, double>(11.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Right),
+                },
+                new Vector<Degrees, double>(3.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                new[]
+                {
+                    new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Straight, new Angle<Degrees, double>(720.0)),
+                    new Vector<Degrees, double>(33.0, new Angle<Degrees, double>(360.0), new Angle<Degrees, double>(360.0)),
+                }
+            },
+            {
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value,
+                        new Angle<Degrees, double>(value + 1),
+                        new Angle<Degrees, double>(value + 2)))
+                    .ToArray(),
+                new Vector<Degrees, double>(3.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value * 3,
+                        new Angle<Degrees, double>((value + 1) * 2),
+                        new Angle<Degrees, double>((value + 2) * 4)))
+                    .ToArray()
+            },
+        };
+
+    public static TheoryData<Vector<Degrees, double>[], Vector<Degrees, double>[], Vector<Degrees, double>[]> SubtractVectorData
+        => new()
+        {
+            {
+                Array.Empty<Vector<Degrees, double>>(),
+                Array.Empty<Vector<Degrees, double>>(),
+                Array.Empty<Vector<Degrees, double>>()
+            },
+            {
+                new[] { new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right) },
+                new[] { new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Straight) },
+                new[] { new Vector<Degrees, double>(-2.0, new Angle<Degrees, double>(-90.0), new Angle<Degrees, double>(-90.0)) }
+            },
+            {
+                new[]
+                {
+                    new Vector<Degrees, double>(1.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Straight),
+                    new Vector<Degrees, double>(11.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Right),
+                },
+                new[]
+                {
+                    new Vector<Degrees, double>(3.0, Angle<Degrees, double>.Right, Angle<Degrees, double>.Right),
+                    new Vector<Degrees, double>(2.0, new Angle<Degrees, double>(45.0), Angle<Degrees, double>.Straight),
+                },
+                new[]
+                {
+                    new Vector<Degrees, double>(-2.0, Angle<Degrees, double>.Zero, Angle<Degrees, double>.Right),
+                    new Vector<Degrees, double>(9.0, new Angle<Degrees, double>(135.0), new Angle<Degrees, double>(-90.0)),
+                }
+            },
+            {
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value + 1,
+                        new Angle<Degrees, double>(value + 2),
+                        new Angle<Degrees, double>(value + 3)))
+                    .ToArray(),
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value,
+                        new Angle<Degrees, double>(value + 1),
+                        new Angle<Degrees, double>(value + 2)))
+                    .ToArray(),
+                Enumerable.Range(0, 97)
+                    .Select(_ => new Vector<Degrees, double>(
+                        1.0,
+                        new Angle<Degrees, double>(1.0),
+                        new Angle<Degrees, double>(1.0)))
+                    .ToArray()
+            },
+        };
+
+    public static TheoryData<Vector<Degrees, double>[], Vector<Degrees, double>, Vector<Degrees, double>[]> DivideValueData
+        => new()
+        {
+            {
+                Array.Empty<Vector<Degrees, double>>(),
+                new Vector<Degrees, double>(2.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                Array.Empty<Vector<Degrees, double>>()
+            },
+            {
+                new[] { new Vector<Degrees, double>(8.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Straight) },
+                new Vector<Degrees, double>(2.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                new[] { new Vector<Degrees, double>(4.0, Angle<Degrees, double>.Right, new Angle<Degrees, double>(45.0)) }
+            },
+            {
+                new[]
+                {
+                    new Vector<Degrees, double>(8.0, Angle<Degrees, double>.Straight, Angle<Degrees, double>.Straight),
+                    new Vector<Degrees, double>(18.0, new Angle<Degrees, double>(270.0), Angle<Degrees, double>.Right),
+                },
+                new Vector<Degrees, double>(2.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                new[]
+                {
+                    new Vector<Degrees, double>(4.0, Angle<Degrees, double>.Right, new Angle<Degrees, double>(45.0)),
+                    new Vector<Degrees, double>(9.0, new Angle<Degrees, double>(135.0), new Angle<Degrees, double>(22.5)),
+                }
+            },
+            {
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        value + 1,
+                        new Angle<Degrees, double>(value + 2),
+                        new Angle<Degrees, double>(value + 4)))
+                    .ToArray(),
+                new Vector<Degrees, double>(2.0, new Angle<Degrees, double>(2.0), new Angle<Degrees, double>(4.0)),
+                Enumerable.Range(0, 97)
+                    .Select(value => new Vector<Degrees, double>(
+                        (value + 1) / 2.0,
+                        new Angle<Degrees, double>((value + 2) / 2.0),
+                        new Angle<Degrees, double>((value + 4) / 4.0)))
+                    .ToArray()
+            },
+        };
+
+    [Theory]
+    [MemberData(nameof(SubtractValueData))]
+    public void Subtract_Value_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+        var result = new Vector<Degrees, double>[source.Length];
+
+        // act
+        Vector.Subtract(source, value, result);
+
+        // assert
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(SubtractValueData))]
+    public void Subtract_Value_Inplace_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+
+        // act
+        Vector.Subtract(source, value, source);
+
+        // assert
+        source.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(SubtractVectorData))]
+    public void Subtract_Vector_Should_Succeed(Vector<Degrees, double>[] left, Vector<Degrees, double>[] right, Vector<Degrees, double>[] expected)
+    {
+        var result = new Vector<Degrees, double>[left.Length];
+
+        Vector.Subtract(left, right, result);
+
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(SubtractVectorData))]
+    public void Subtract_Vector_Inplace_Should_Succeed(Vector<Degrees, double>[] left, Vector<Degrees, double>[] right, Vector<Degrees, double>[] expected)
+    {
+        Vector.Subtract(left, right, left);
+
+        left.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(MultiplyValueData))]
+    public void Multiply_Value_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+        var result = new Vector<Degrees, double>[source.Length];
+
+        // act
+        Vector.Multiply(source, value, result);
+
+        // assert
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(MultiplyValueData))]
+    public void Multiply_Value_Inplace_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+
+        // act
+        Vector.Multiply(source, value, source);
+
+        // assert
+        source.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(DivideValueData))]
+    public void Divide_Value_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+        var result = new Vector<Degrees, double>[source.Length];
+
+        // act
+        Vector.Divide(source, value, result);
+
+        // assert
+        result.Should().Equal(expected);
+    }
+
+    [Theory]
+    [MemberData(nameof(DivideValueData))]
+    public void Divide_Value_Inplace_Should_Succeed(Vector<Degrees, double>[] source, Vector<Degrees, double> value, Vector<Degrees, double>[] expected)
+    {
+        // arrange
+
+        // act
+        Vector.Divide(source, value, source);
+
+        // assert
+        source.Should().Equal(expected);
+    }
+}

--- a/src/NetFabric.Numerics/Spherical/VectorAverage.cs
+++ b/src/NetFabric.Numerics/Spherical/VectorAverage.cs
@@ -1,0 +1,83 @@
+namespace NetFabric.Numerics.Spherical;
+
+public static partial class Vector
+{
+    /// <summary>
+    /// Calculates the average of a collection of vectors.
+    /// </summary>
+    /// <param name="source">The enumerable collection of vectors.</param>
+    /// <returns>The average of the vectors in the collection, or <see langword="null"/> if the collection is empty.</returns>
+    /// <remarks>
+    /// The average of vectors is computed by summing all the vectors in the given <paramref name="source"/> collection
+    /// and dividing by the number of elements.
+    /// </remarks>
+    public static Vector<TAngleUnits, T>? Average<TAngleUnits, T>(this IEnumerable<Vector<TAngleUnits, T>> source)
+        where TAngleUnits : IAngleUnits
+        where T : struct, IFloatingPoint<T>, IMinMaxValue<T>
+    {
+        if (source.TryGetSpan(out var span))
+            return Average(span);
+
+        var sumRadius = T.Zero;
+        var sumAzimuth = T.Zero;
+        var sumPolar = T.Zero;
+        var count = T.Zero;
+        foreach (var vector in source)
+        {
+            checked
+            {
+                sumRadius += vector.Radius;
+                sumAzimuth += vector.Azimuth.Value;
+                sumPolar += vector.Polar.Value;
+                count++;
+            }
+        }
+        return T.IsZero(count)
+            ? null
+            : new Vector<TAngleUnits, T>(sumRadius / count, new Angle<TAngleUnits, T>(sumAzimuth / count), new Angle<TAngleUnits, T>(sumPolar / count));
+    }
+
+    /// <summary>
+    /// Calculates the average of an array of vectors.
+    /// </summary>
+    /// <param name="source">The array of vectors.</param>
+    /// <returns>The average of the vectors in the array, or <see langword="null"/> if the array is empty.</returns>
+    /// <remarks>
+    /// The average of vectors is computed by summing all the vectors in the given <paramref name="source"/> array
+    /// and dividing by the number of elements.
+    /// </remarks>
+    public static Vector<TAngleUnits, T>? Average<TAngleUnits, T>(this Vector<TAngleUnits, T>[] source)
+        where TAngleUnits : IAngleUnits
+        where T : struct, IFloatingPoint<T>, IMinMaxValue<T>
+        => Average(source.AsSpan());
+
+    /// <summary>
+    /// Calculates the average of a span of vectors.
+    /// </summary>
+    /// <param name="source">The <see cref="Span{T}"/> of vectors.</param>
+    /// <returns>The average of the vectors in the span, or <see langword="null"/> if the span is empty.</returns>
+    /// <remarks>
+    /// The average of vectors is computed by summing all the vectors in the given <paramref name="source"/> span
+    /// and dividing by the number of elements.
+    /// </remarks>
+    public static Vector<TAngleUnits, T>? Average<TAngleUnits, T>(this Span<Vector<TAngleUnits, T>> source)
+        where TAngleUnits : IAngleUnits
+        where T : struct, IFloatingPoint<T>, IMinMaxValue<T>
+        => Average((ReadOnlySpan<Vector<TAngleUnits, T>>)source);
+
+    /// <summary>
+    /// Calculates the average of a read-only span of vectors.
+    /// </summary>
+    /// <param name="source">The <see cref="ReadOnlySpan{T}"/> of vectors.</param>
+    /// <returns>The average of the vectors in the span, or <see langword="null"/> if the span is empty.</returns>
+    /// <remarks>
+    /// The average of vectors is computed by summing all the vectors in the given <paramref name="source"/> span
+    /// and dividing by the number of elements.
+    /// </remarks>
+    public static Vector<TAngleUnits, T>? Average<TAngleUnits, T>(this ReadOnlySpan<Vector<TAngleUnits, T>> source)
+        where TAngleUnits : IAngleUnits
+        where T : struct, IFloatingPoint<T>, IMinMaxValue<T>
+        => source.Length is 0
+            ? null
+            : Sum(source) / T.CreateChecked(source.Length);
+}


### PR DESCRIPTION
Summary
- Added the missing Spherical vector average implementation.
- Added Spherical average and span subtract/multiply/divide tests.
- Discovery showed VectorSum.cs and VectorSpanOperations.cs already existed, so only VectorAverage.cs was needed on the production side.

Validation
- dotnet format NetFabric.Numerics.slnx --verify-no-changes => exit 0
- dotnet restore && dotnet build --no-restore -c Release => exit 0
- dotnet test --no-build --verbosity normal -c Release => exit 0
- Total tests: 364, Passed: 364

Review
- tribunal verdict: approved
- merged findings: average uses arithmetic means for angle components; test naming follows sibling conventions; IEnumerable null behavior is inherited from sibling files.